### PR TITLE
filter out deleted file for linter

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@ async function getAllFiles() {
 
 async function getGitDiff() {
   const p = new Promise((yes, no) => {
-    exec("git diff --cached --diff-filter=ACM --name-only", (error, stdout, stderr) => {
+    exec("git diff --cached --diff-filter=ACMR --name-only", (error, stdout, stderr) => {
       if (error) {
         console.log(error);
         no(error);


### PR DESCRIPTION
I think it can be nice to filter out deleted git files for linter. Otherwise, an error can throw for cannot find the deleted file and git commit will fail.