### PR TITLE
Enforce 1 line between class members

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ module.exports = {
     "tslint:recommended",
     "tslint-react",
     "tslint-config-prettier",
+    "tslint-lines-between-class-members",
     "tslint-plugin-prettier"
   ],
   "jsRules": {},
@@ -82,6 +83,7 @@ module.exports = {
         "printWidth": 100,
         "arrowParens": "avoid"
       }
-    }
+    },
+    "lines-between-class-members": [true, 1]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -394,6 +394,11 @@
       "resolved": "https://registry.npmjs.org/tslint-config-prettier/-/tslint-config-prettier-1.18.0.tgz",
       "integrity": "sha512-xPw9PgNPLG3iKRxmK7DWr+Ea/SzrvfHtjFt5LBl61gk2UBG/DB9kCXRjv+xyIU1rUtnayLeMUVJBcMX8Z17nDg=="
     },
+    "tslint-lines-between-class-members": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/tslint-lines-between-class-members/-/tslint-lines-between-class-members-1.3.6.tgz",
+      "integrity": "sha512-g9bxloPZVrkZLxLl+auqxWpZ4QJPTQLZocQN1zeD01pZOiH1m1OjDKwhDRjJD17IVsdTXd2M/Wp1+A9tfLr1Iw=="
+    },
     "tslint-plugin-prettier": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/tslint-plugin-prettier/-/tslint-plugin-prettier-2.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "stylelint-prettier": "^1.1.2",
     "stylelint-scss": "^3.19.0",
     "tslint-config-prettier": "^1.18.0",
+    "tslint-lines-between-class-members": "^1.3.6",
     "tslint-plugin-prettier": "^2.3.0",
     "tslint-react": "^5.0.0"
   },


### PR DESCRIPTION
This will ensure there is always one blank line between class methods (it allows one-liners like fields to touch each other).

Unfortunately this only works inside of a class. We cannot yet enforce that class/interface/function definitions do not touch each other. For that, we will have to migrate to ESLint.