### PR TITLE
Eslint update

### DIFF
--- a/.changeset/chilly-paws-kick.md
+++ b/.changeset/chilly-paws-kick.md
@@ -1,0 +1,5 @@
+---
+'@awesome-code-style/eslint-config': patch
+---
+
+Expand version range for simple-import-sort

--- a/.changeset/lemon-mirrors-help.md
+++ b/.changeset/lemon-mirrors-help.md
@@ -1,0 +1,5 @@
+---
+'@awesome-code-style/eslint-config': minor
+---
+
+Enable consistent-type-imports by default

--- a/.changeset/nervous-queens-press.md
+++ b/.changeset/nervous-queens-press.md
@@ -1,0 +1,5 @@
+---
+'@awesome-code-style/eslint-config': patch
+---
+
+Remove 'header' plugin, which was never part of the base ruleset

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,4 +20,4 @@ jobs:
           cache: 'npm'
       - run: npm install --prefer-offline --no-audit
       - name: Check for changes requiring a changeset
-        run: npx changeset status --since=master
+        run: npx changeset status --since=origin/master

--- a/package-lock.json
+++ b/package-lock.json
@@ -6502,7 +6502,7 @@
         "eslint-plugin-import": "^2.25.2",
         "eslint-plugin-react": "^7.26.1",
         "eslint-plugin-react-hooks": "^4.2.0",
-        "eslint-plugin-simple-import-sort": "^7.0.0 || ^8.0.0",
+        "eslint-plugin-simple-import-sort": ">= 7.0.0",
         "eslint-plugin-unused-imports": "^2.0.0"
       },
       "peerDependenciesMeta": {

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -34,6 +34,7 @@ module.exports = {
     // @typescript-eslint (adds)
     '@typescript-eslint/ban-tslint-comment': 'error',
     '@typescript-eslint/consistent-type-assertions': 'error',
+    '@typescript-eslint/consistent-type-imports': ['warn', { prefer: 'type-imports' }],
     '@typescript-eslint/lines-between-class-members': [
       'warn',
       'always',

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -9,13 +9,7 @@ module.exports = {
   parserOptions: {
     sourceType: 'module',
   },
-  plugins: [
-    'eslint-plugin-header',
-    'eslint-plugin-import',
-    'eslint-plugin-unused-imports',
-    'simple-import-sort',
-    '@typescript-eslint',
-  ],
+  plugins: ['@typescript-eslint', 'import', 'simple-import-sort', 'unused-imports'],
   rules: {
     // eslint (adds)
     'eqeqeq': ['error', 'smart'],

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -29,7 +29,7 @@
     "eslint-plugin-import": "^2.25.2",
     "eslint-plugin-react": "^7.26.1",
     "eslint-plugin-react-hooks": "^4.2.0",
-    "eslint-plugin-simple-import-sort": "^7.0.0 || ^8.0.0",
+    "eslint-plugin-simple-import-sort": ">= 7.0.0",
     "eslint-plugin-unused-imports": "^2.0.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
- Expand version range for simple-import-sort
- Remove 'header' plugin, which was never part of the base ruleset
- Enable consistent-type-imports by default